### PR TITLE
Remove login requirement from API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
 CORS_ORIGIN=http://localhost:3000
 PORT=3000
-PROXY_USER=oslotom
-PROXY_PASS=oslotom
 # ==== Maskinporten (fyll inn fra Digdir-oppsettet) ====
 MP_CLIENT_ID=
 MP_TOKEN_ENDPOINT=

--- a/index.html
+++ b/index.html
@@ -82,33 +82,20 @@
       <h2 class="text-lg font-bold mb-3">server.js (proxy)</h2>
       <pre class="text-xs bg-slate-900 text-slate-100 p-4 rounded-xl overflow-auto"><code>// server.js - Node/Express proxy for Brønnøysund + Maskinporten (lukket)
 // 1) npm init -y
-// 2) npm i express node-fetch cors dotenv basic-auth jose
+// 2) npm i express node-fetch cors dotenv jose
 // 3) node server.js
 
 import express from 'express';
 import fetch from 'node-fetch';
 import cors from 'cors';
 import dotenv from 'dotenv';
-import basicAuth from 'basic-auth';
 import { SignJWT, importPKCS8 } from 'jose';
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
 
-// Basic auth beskyttelse av API
-const API_USER = process.env.PROXY_USER || 'oslotom';
-const API_PASS = process.env.PROXY_PASS || 'oslotom';
-app.use('/api', (req, res, next) => {
-  const creds = basicAuth(req);
-  if (!creds || creds.name !== API_USER || creds.pass !== API_PASS) {
-    res.set('WWW-Authenticate', 'Basic realm="Access"');
-    return res.status(401).send('Authentication required.');
-  }
-  next();
-});
-
-app.use(cors({ origin: process.env.CORS_ORIGIN || true }));
+app.use('/api', cors({ origin: process.env.CORS_ORIGIN || true }));
 
 async function proxyJSON(url, init = {}) {
   const r = await fetch(url, { headers: { Accept: 'application/json' }, ...init });
@@ -215,10 +202,8 @@ app.listen(PORT, () => console.log(`Proxy running on http://localhost:${PORT}`))
 </code></pre>
 
       <h3 class="text-sm font-semibold mt-6 mb-2">.env</h3>
-      <pre class="text-xs bg-slate-900 text-slate-100 p-4 rounded-xl overflow-auto"><code>CORS_ORIGIN=http://localhost:3000
+        <pre class="text-xs bg-slate-900 text-slate-100 p-4 rounded-xl overflow-auto"><code>CORS_ORIGIN=http://localhost:3000
 PORT=3001
-PROXY_USER=oslotom
-PROXY_PASS=oslotom
 # ==== Maskinporten (fyll inn fra Digdir-oppsettet) ====
 MP_CLIENT_ID=
 MP_TOKEN_ENDPOINT=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "selskapsinfo",
       "version": "1.0.0",
       "dependencies": {
-        "basic-auth": "^2.0.1",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -150,18 +149,6 @@
       "license": "MIT",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
-      }
-    },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/batch": {
@@ -1977,12 +1964,6 @@
       "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test": "echo \"No tests specified\""
   },
   "dependencies": {
-    "basic-auth": "^2.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",

--- a/selskapsanalyse.html
+++ b/selskapsanalyse.html
@@ -77,33 +77,20 @@
       <h2 class="text-lg font-bold mb-3">server.js (proxy)</h2>
       <pre class="text-xs bg-slate-900 text-slate-100 p-4 rounded-xl overflow-auto"><code>// server.js - Node/Express proxy for Brønnøysund + Maskinporten (lukket)
 // 1) npm init -y
-// 2) npm i express node-fetch cors dotenv basic-auth jose
+// 2) npm i express node-fetch cors dotenv jose
 // 3) node server.js
 
 import express from 'express';
 import fetch from 'node-fetch';
 import cors from 'cors';
 import dotenv from 'dotenv';
-import basicAuth from 'basic-auth';
 import { SignJWT, importPKCS8 } from 'jose';
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
 
-// Basic auth beskyttelse av API
-const API_USER = process.env.PROXY_USER || 'oslotom';
-const API_PASS = process.env.PROXY_PASS || 'oslotom';
-app.use('/api', (req, res, next) => {
-  const creds = basicAuth(req);
-  if (!creds || creds.name !== API_USER || creds.pass !== API_PASS) {
-    res.set('WWW-Authenticate', 'Basic realm="Access"');
-    return res.status(401).send('Authentication required.');
-  }
-  next();
-});
-
-app.use(cors({ origin: process.env.CORS_ORIGIN || true }));
+app.use('/api', cors({ origin: process.env.CORS_ORIGIN || true }));
 
 async function proxyJSON(url, init = {}) {
   const r = await fetch(url, { headers: { Accept: 'application/json' }, ...init });
@@ -210,10 +197,8 @@ app.listen(PORT, () => console.log(`Proxy running on http://localhost:${PORT}`))
 </code></pre>
 
       <h3 class="text-sm font-semibold mt-6 mb-2">.env</h3>
-      <pre class="text-xs bg-slate-900 text-slate-100 p-4 rounded-xl overflow-auto"><code>CORS_ORIGIN=http://localhost:3000
+        <pre class="text-xs bg-slate-900 text-slate-100 p-4 rounded-xl overflow-auto"><code>CORS_ORIGIN=http://localhost:3000
 PORT=3001
-PROXY_USER=oslotom
-PROXY_PASS=oslotom
 # ==== Maskinporten (fyll inn fra Digdir-oppsettet) ====
 MP_CLIENT_ID=
 MP_TOKEN_ENDPOINT=

--- a/server.js
+++ b/server.js
@@ -2,25 +2,12 @@ import express from 'express';
 import fetch from 'node-fetch';
 import cors from 'cors';
 import dotenv from 'dotenv';
-import basicAuth from 'basic-auth';
 import { SignJWT, importPKCS8 } from 'jose';
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-
-// Basic auth protection for API routes
-const API_USER = process.env.PROXY_USER || 'oslotom';
-const API_PASS = process.env.PROXY_PASS || 'oslotom';
-app.use('/api', (req, res, next) => {
-  const creds = basicAuth(req);
-  if (!creds || creds.name !== API_USER || creds.pass !== API_PASS) {
-    res.set('WWW-Authenticate', 'Basic realm="Access"');
-    return res.status(401).send('Authentication required.');
-  }
-  next();
-});
 
 app.use('/api', cors({ origin: process.env.CORS_ORIGIN || true }));
 


### PR DESCRIPTION
## Summary
- drop Basic Auth middleware so API endpoints are publicly accessible
- update documentation and env examples to omit proxy credentials
- remove `basic-auth` dependency

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899d3da5b288326af10554374547aeb